### PR TITLE
Fifo bundle was not removed when RecordContext is destroyed

### DIFF
--- a/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
+++ b/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
@@ -516,6 +516,10 @@ public:
                 std::forward<const juce::Array<AudioTrack*>>(p_TrackList),
                 FileName);
         }
+        ~RecordingContext()
+        {
+            engine.destroyFifoBundle(m_SampleID);
+        }
         // BEATCONNECT MODIFICATION END
 
         Engine& engine;

--- a/modules/tracktion_engine/utilities/tracktion_Engine.cpp
+++ b/modules/tracktion_engine/utilities/tracktion_Engine.cpp
@@ -272,8 +272,7 @@ Engine::FifoBundle::FifoBundle(const double p_PunchIn, const juce::Array<AudioTr
         if (nullptr != p)
         {
             const juce::String Temp1 = p->state.getProperty("uuid");
-            const std::string Temp2(Temp1.getCharPointer());
-            m_ListTracksID.push_back(Temp2);
+            m_ListTracksID.push_back(Temp1.toStdString());
         }
     }
 }
@@ -305,6 +304,12 @@ void Engine::createFifoBundle(
         p_PunchIn, 
         std::forward<const juce::Array<AudioTrack*>>(p_Tracks),
         p_FileName);
+}
+
+void Engine::destroyFifoBundle(const juce::Uuid& p_FifoID)
+{
+    jassert(p_FifoID != 0);
+    m_ListFifoBundle.erase(p_FifoID);
 }
 // BEATCONNECT MODIFICATION END
 

--- a/modules/tracktion_engine/utilities/tracktion_Engine.h
+++ b/modules/tracktion_engine/utilities/tracktion_Engine.h
@@ -49,6 +49,7 @@ public:
     const std::map<juce::Uuid, std::unique_ptr<Engine::FifoBundle>>& getAudioFifo() const;
     void addBlockToAudioFifo(const juce::Uuid& p_FifoID, const juce::AudioBuffer<float>& p_NextBuffer);
     void createFifoBundle(const juce::Uuid& p_FifoID, const double p_PunchIn, const juce::Array<AudioTrack*>&& p_Tracks, const std::string& p_FileName);
+    void destroyFifoBundle(const juce::Uuid& p_FifoID);
     // BEATCONNECT MODIFICATION END
 
     TemporaryFileManager& getTemporaryFileManager() const;


### PR DESCRIPTION
Since the list of fifo bundles lives in the Engine and RecordingContext are created and destroyed for every recording, new fifo bundles are created for every recording. The list keeps growing. I've added a remove of the fifo bundle when the RecordingContext is destroyed.
