### PR TITLE
Reintegrate relay

### DIFF
--- a/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
+++ b/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
@@ -1057,6 +1057,18 @@ public:
             return;
 
         auto& wi = getWaveInput();
+
+        // TEST
+        if (wi.getIsRelay() && wi.isEnabled())
+        {
+            inputBuffer.clear();
+            if (nullptr != edit.engine.getDeviceManager().realyBufferProcessor)
+                edit.engine.getDeviceManager().realyBufferProcessor(inputBuffer);
+
+            return;
+        }
+        // TEST
+
         auto& channelSet = wi.getChannelSet();
         inputBuffer.setSize (channelSet.size(), numSamples);
 
@@ -1068,75 +1080,6 @@ public:
                 juce::FloatVectorOperations::copy (inputBuffer.getWritePointer (inputIndex),
                                                    allChannels[ci.indexInDevice], numSamples);
             }
-            // TEST
-            else if (wi.getIsRelay())
-            {
-                // DBG("Need Realy Processing : " << allChannels[0][20]);
-
-                // Can't hear shit.
-                // inputBuffer.setSize(1, numSamples);
-                // for (int ch = 0; ch < 1; ch++)
-                // {
-                //     for (int sam = 0; sam < numSamples; sam++)
-                //         inputBuffer.getArrayOfWritePointers()[ch][sam] = 0.00457764 + 0.0005;
-                // }
-
-                // Can't hear shit.
-                //  inputBuffer.setSize(numChannels, numSamples);
-                //  for (int ch = 0; ch < numChannels; ch++)
-                //  {
-                //      for (int sam = 0; sam < numSamples; sam++)
-                //          inputBuffer.getArrayOfWritePointers()[ch][sam] = -0.56523f;
-                //  }
-
-                // Can't hear shit.
-                // inputBuffer.setSize(1, numSamples);
-                // for (int sam = 0; sam < numSamples; sam++)
-                //     inputBuffer.getArrayOfWritePointers()[0][sam] = 0.00457764;
-
-                // Can't hear shit.
-                //  inputBuffer.setSize(1, 30);
-                //  int sam = 0;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00183105   ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00289917   ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00686646    ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00192261    ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.000518799  ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00384521    ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.000152588  ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00143433   ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00344849    ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00518799   ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00811768   ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00335693    ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.0039978    ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00405884   ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00439453    ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00213623    ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00320435    ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00442505   ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.000671387  ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00088501   ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.000671387  ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00469971    ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00650024    ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00256348   ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.000946045   ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.000793457   ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00637817   ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00463867   ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00436401    ;
-                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00350952   ;
-
-                // Can hear.
-                // inputBuffer.setSize(2, numSamples);
-                // juce::FloatVectorOperations::copy(inputBuffer.getWritePointer(0), allChannels[0], numSamples);
-                // juce::FloatVectorOperations::copy(inputBuffer.getWritePointer(1), allChannels[0], numSamples);
-
-                if (nullptr != edit.engine.getDeviceManager().realyBufferProcessor)
-                    edit.engine.getDeviceManager().realyBufferProcessor(inputBuffer);
-            }
-            // TEST
             else
             {
                 jassertfalse; // Is an input device getting created with more channels than the total number of device channels?
@@ -1151,34 +1094,44 @@ public:
         CRASH_TRACER
         copyIncomingDataIntoBuffer (allChannels, numChannels, numSamples);
 
-        auto inputGainDb = getWaveInput().inputGainDb;
-
-        if (inputGainDb > 0.01f || inputGainDb < -0.01f)
-            inputBuffer.applyGain (0, numSamples, dbToGain (inputGainDb));
-
-        if (measurerToUpdate != nullptr)
-            measurerToUpdate->processBuffer (inputBuffer, 0, numSamples);
-
-        if (retrospectiveBuffer != nullptr)
+        // TEST
+        auto& wi = getWaveInput();
+        if (!wi.getIsRelay())
         {
-            if (addToRetrospective)
+        // TEST
+
+            auto inputGainDb = getWaveInput().inputGainDb;
+
+            if (inputGainDb > 0.01f || inputGainDb < -0.01f)
+                inputBuffer.applyGain(0, numSamples, dbToGain(inputGainDb));
+
+            if (measurerToUpdate != nullptr)
+                measurerToUpdate->processBuffer(inputBuffer, 0, numSamples);
+
+            if (retrospectiveBuffer != nullptr)
             {
-                retrospectiveBuffer->updateSizeIfNeeded (inputBuffer.getNumChannels(),
-                                                         edit.engine.getDeviceManager().getSampleRate());
-                retrospectiveBuffer->processBuffer (streamTime, inputBuffer, numSamples);
+                if (addToRetrospective)
+                {
+                    retrospectiveBuffer->updateSizeIfNeeded(inputBuffer.getNumChannels(),
+                        edit.engine.getDeviceManager().getSampleRate());
+                    retrospectiveBuffer->processBuffer(streamTime, inputBuffer, numSamples);
+                }
+
+                retrospectiveBuffer->syncToEdit(edit, context, streamTime, numSamples);
             }
 
-            retrospectiveBuffer->syncToEdit (edit, context, streamTime, numSamples);
-        }
+            {
+                const juce::ScopedLock sl (consumerLock);
 
-        {
-            const juce::ScopedLock sl (consumerLock);
+                for (auto n : consumers)
+                    n->acceptInputBuffer (choc::buffer::createChannelArrayView (inputBuffer.getArrayOfWritePointers(),
+                                                                                (choc::buffer::ChannelCount) inputBuffer.getNumChannels(),
+                                                                                (choc::buffer::FrameCount) numSamples));
+            }
 
-            for (auto n : consumers)
-                n->acceptInputBuffer (choc::buffer::createChannelArrayView (inputBuffer.getArrayOfWritePointers(),
-                                                                            (choc::buffer::ChannelCount) inputBuffer.getNumChannels(),
-                                                                            (choc::buffer::FrameCount) numSamples));
+        // TEST
         }
+        // TEST
 
         const juce::ScopedLock sl (contextLock);
 

--- a/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
+++ b/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
@@ -1062,10 +1062,15 @@ public:
         if (wi.getIsRelay() && wi.isEnabled())
         {
             // Reset the size to 0.
-            // realyBufferProcessor with set the correct size.
+            // realyBufferProcessor will set the correct size.
             inputBuffer.setSize(inputBuffer.getNumChannels(), 0, false, true);
-            if (nullptr != edit.engine.getDeviceManager().realyBufferProcessor)
-                edit.engine.getDeviceManager().realyBufferProcessor(inputBuffer);
+
+            // relayBufferProcessor is a shared resource.
+            // This callback function will be set to nullptr when the Relay disconnects or the application is closed.
+            std::unique_lock<std::mutex> lock(edit.engine.getDeviceManager().m_muRelayCallback);
+
+            if (nullptr != edit.engine.getDeviceManager().relayBufferProcessor)
+                edit.engine.getDeviceManager().relayBufferProcessor(inputBuffer);
 
             return;
         }

--- a/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
+++ b/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
@@ -1068,6 +1068,75 @@ public:
                 juce::FloatVectorOperations::copy (inputBuffer.getWritePointer (inputIndex),
                                                    allChannels[ci.indexInDevice], numSamples);
             }
+            // TEST
+            else if (wi.getIsRelay())
+            {
+                // DBG("Need Realy Processing : " << allChannels[0][20]);
+
+                // Can't hear shit.
+                // inputBuffer.setSize(1, numSamples);
+                // for (int ch = 0; ch < 1; ch++)
+                // {
+                //     for (int sam = 0; sam < numSamples; sam++)
+                //         inputBuffer.getArrayOfWritePointers()[ch][sam] = 0.00457764 + 0.0005;
+                // }
+
+                // Can't hear shit.
+                //  inputBuffer.setSize(numChannels, numSamples);
+                //  for (int ch = 0; ch < numChannels; ch++)
+                //  {
+                //      for (int sam = 0; sam < numSamples; sam++)
+                //          inputBuffer.getArrayOfWritePointers()[ch][sam] = -0.56523f;
+                //  }
+
+                // Can't hear shit.
+                // inputBuffer.setSize(1, numSamples);
+                // for (int sam = 0; sam < numSamples; sam++)
+                //     inputBuffer.getArrayOfWritePointers()[0][sam] = 0.00457764;
+
+                // Can't hear shit.
+                //  inputBuffer.setSize(1, 30);
+                //  int sam = 0;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00183105   ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00289917   ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00686646    ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00192261    ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.000518799  ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00384521    ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.000152588  ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00143433   ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00344849    ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00518799   ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00811768   ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00335693    ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.0039978    ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00405884   ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00439453    ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00213623    ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00320435    ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00442505   ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.000671387  ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00088501   ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.000671387  ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00469971    ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00650024    ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00256348   ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.000946045   ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.000793457   ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00637817   ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00463867   ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = 0.00436401    ;
+                //  inputBuffer.getArrayOfWritePointers()[0][sam++] = -0.00350952   ;
+
+                // Can hear.
+                // inputBuffer.setSize(2, numSamples);
+                // juce::FloatVectorOperations::copy(inputBuffer.getWritePointer(0), allChannels[0], numSamples);
+                // juce::FloatVectorOperations::copy(inputBuffer.getWritePointer(1), allChannels[0], numSamples);
+
+                if (nullptr != edit.engine.getDeviceManager().realyBufferProcessor)
+                    edit.engine.getDeviceManager().realyBufferProcessor(inputBuffer);
+            }
+            // TEST
             else
             {
                 jassertfalse; // Is an input device getting created with more channels than the total number of device channels?
@@ -1227,6 +1296,10 @@ WaveInputDevice::WaveInputDevice (Engine& e, const juce::String& deviceName, con
       deviceType (t),
       channelSet (createChannelSet (channels))
 {
+    // TEST
+    isRelay = (deviceName == "Relay");
+    // TEST
+
     loadProps();
 }
 
@@ -1366,6 +1439,13 @@ juce::String WaveInputDevice::getSelectableDescription()
 
     return InputDevice::getSelectableDescription();
 }
+
+// TEST
+bool WaveInputDevice::getIsRelay() const
+{
+    return isRelay;
+}
+// TEST
 
 bool WaveInputDevice::isStereoPair() const
 {

--- a/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
+++ b/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
@@ -1136,18 +1136,18 @@ public:
                 retrospectiveBuffer->syncToEdit(edit, context, streamTime, numSamples);
             }
 
-            {
-                const juce::ScopedLock sl (consumerLock);
-
-                for (auto n : consumers)
-                    n->acceptInputBuffer (choc::buffer::createChannelArrayView (inputBuffer.getArrayOfWritePointers(),
-                                                                                (choc::buffer::ChannelCount) inputBuffer.getNumChannels(),
-                                                                                (choc::buffer::FrameCount) numSamples));
-            }
-
         // BEATCONNECT MODIFICATION START (RELAY)
         }
         // BEATCONNECT MODIFICATION END (RELAY)
+
+        {
+            const juce::ScopedLock sl(consumerLock);
+
+            for (auto n : consumers)
+                n->acceptInputBuffer(choc::buffer::createChannelArrayView(inputBuffer.getArrayOfWritePointers(),
+                    (choc::buffer::ChannelCount)inputBuffer.getNumChannels(),
+                    (choc::buffer::FrameCount)numSamples));
+        }
 
         const juce::ScopedLock sl (contextLock);
 

--- a/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.h
+++ b/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.h
@@ -71,6 +71,10 @@ public:
     //==============================================================================
     juce::String getSelectableDescription() override;
 
+    // TEST
+    bool getIsRelay() const;
+    // TEST
+
 protected:
     juce::String openDevice();
     void closeDevice();
@@ -90,6 +94,10 @@ private:
     float recordTriggerDb = 0;
     double recordAdjustMs = 0;
     std::unique_ptr<RetrospectiveRecordBuffer> retrospectiveBuffer;
+
+    // TEST
+    bool isRelay = false;
+    // TEST
 
     void loadProps();
     void saveProps();

--- a/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.h
+++ b/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.h
@@ -19,6 +19,11 @@ namespace tracktion_engine
 class WaveInputDevice   : public InputDevice
 {
 public:
+
+    // BEATCONNECT MODIFICATION START (RELAY)
+    static const juce::String g_Relay;
+    // BEATCONNECT MODIFICATION END (RELAY)
+
     //==============================================================================
     WaveInputDevice (Engine&, const juce::String& name, const juce::String& type,
                      const std::vector<ChannelIndex>&, DeviceType);
@@ -71,9 +76,9 @@ public:
     //==============================================================================
     juce::String getSelectableDescription() override;
 
-    // TEST
+    // BEATCONNECT MODIFICATION START (RELAY)
     bool getIsRelay() const;
-    // TEST
+    // BEATCONNECT MODIFICATION END (RELAY)
 
 protected:
     juce::String openDevice();
@@ -95,9 +100,9 @@ private:
     double recordAdjustMs = 0;
     std::unique_ptr<RetrospectiveRecordBuffer> retrospectiveBuffer;
 
-    // TEST
+    // BEATCONNECT MODIFICATION START (RELAY)
     bool isRelay = false;
-    // TEST
+    // BEATCONNECT MODIFICATION END (RELAY)
 
     void loadProps();
     void saveProps();

--- a/modules/tracktion_engine/playback/tracktion_DeviceManager.cpp
+++ b/modules/tracktion_engine/playback/tracktion_DeviceManager.cpp
@@ -129,7 +129,7 @@ struct DeviceManager::WaveDeviceList
             // BEATCONNECT MODIFICATION START (RELAY)
             if (channelNames[i] == WaveInputDevice::g_Relay)
             {
-                descriptions.push_back(WaveDeviceDescription(channelNames[i], i, i + 1, isDeviceEnabled(i) || isDeviceEnabled(i + 1)));
+                descriptions.push_back(WaveDeviceDescription(channelNames[i], i, i + 1, true));
                 ++i;
                 continue;
             }

--- a/modules/tracktion_engine/playback/tracktion_DeviceManager.cpp
+++ b/modules/tracktion_engine/playback/tracktion_DeviceManager.cpp
@@ -114,6 +114,10 @@ struct DeviceManager::WaveDeviceList
             channelNames.set (1, name.replace ("123", "2"));
         }
 
+        // TEST
+        channelNames.add("Relay");
+        // TEST
+
         auto isDeviceEnabled = [this, isInput] (int index)
         {
             return isInput ? dm.isDeviceInEnabled (index) : dm.isDeviceOutEnabled (index);
@@ -121,6 +125,15 @@ struct DeviceManager::WaveDeviceList
 
         for (int i = 0; i < channelNames.size(); ++i)
         {
+            // TEST
+            if (channelNames[i] == "Relay")
+            {
+                descriptions.push_back(WaveDeviceDescription(channelNames[i], i, i + 1, isDeviceEnabled(i) || isDeviceEnabled(i + 1)));
+                ++i;
+                continue;
+            }
+            // TEST
+
             const bool canBeStereo = i < channelNames.size() - 1;
             
             if (canBeStereo && (isInput ? dm.isDeviceInChannelStereo (i) : dm.isDeviceOutChannelStereo (i)))

--- a/modules/tracktion_engine/playback/tracktion_DeviceManager.cpp
+++ b/modules/tracktion_engine/playback/tracktion_DeviceManager.cpp
@@ -114,10 +114,10 @@ struct DeviceManager::WaveDeviceList
             channelNames.set (1, name.replace ("123", "2"));
         }
 
-        // TEST
-        if(isInput)
-            channelNames.add("Relay");
-        // TEST
+        // BEATCONNECT MODIFICATION START (RELAY)
+        if(isInput && dm.m_EnableRealy)
+            channelNames.add(WaveInputDevice::g_Relay);
+        // BEATCONNECT MODIFICATION END (RELAY)
 
         auto isDeviceEnabled = [this, isInput] (int index)
         {
@@ -126,14 +126,14 @@ struct DeviceManager::WaveDeviceList
 
         for (int i = 0; i < channelNames.size(); ++i)
         {
-            // TEST
-            if (channelNames[i] == "Relay")
+            // BEATCONNECT MODIFICATION START (RELAY)
+            if (channelNames[i] == WaveInputDevice::g_Relay)
             {
                 descriptions.push_back(WaveDeviceDescription(channelNames[i], i, i + 1, isDeviceEnabled(i) || isDeviceEnabled(i + 1)));
                 ++i;
                 continue;
             }
-            // TEST
+            // BEATCONNECT MODIFICATION END (RELAY)
 
             const bool canBeStereo = i < channelNames.size() - 1;
             
@@ -608,12 +608,11 @@ void DeviceManager::rebuildWaveDeviceList()
 
     for (const auto& d : lastWaveDeviceList->inputs)
     {
-        auto wi = new WaveInputDevice (engine, d.name, TRANS("Wave Audio Input"), d.channels, InputDevice::waveDevice);
+        auto wi = new WaveInputDevice(engine, d.name, TRANS("Wave Audio Input"), d.channels, InputDevice::waveDevice);
         wi->enabled = d.enabled;
-        waveInputs.add (wi);
+        waveInputs.add(wi);
 
-        TRACKTION_LOG_DEVICE ("Wave In: " + wi->getName() + (wi->isEnabled() ? " (enabled): " : ": ")
-                              + createDescriptionOfChannels (wi->deviceChannels));
+        TRACKTION_LOG_DEVICE("Wave In: " + wi->getName() + (wi->isEnabled() ? " (enabled): " : ": ") + createDescriptionOfChannels(wi->deviceChannels));
     }
 
     for (auto wi : waveInputs)
@@ -1319,5 +1318,13 @@ void DeviceManager::setGlobalOutputAudioProcessor (juce::AudioProcessor* newProc
         if (auto* audioIODevice = deviceManager.getCurrentAudioDevice())
             globalOutputAudioProcessor->prepareToPlay (currentSampleRate, audioIODevice->getCurrentBufferSizeSamples());
 }
+
+// BEATCONNECT MODIFICATION START (RELAY)
+void DeviceManager::enableRelay(bool p_Enable)
+{
+    m_EnableRealy = p_Enable;
+    rebuildWaveDeviceList();
+}
+// BEATCONNECT MODIFICATION END (RELAY)
 
 }

--- a/modules/tracktion_engine/playback/tracktion_DeviceManager.cpp
+++ b/modules/tracktion_engine/playback/tracktion_DeviceManager.cpp
@@ -115,7 +115,8 @@ struct DeviceManager::WaveDeviceList
         }
 
         // TEST
-        channelNames.add("Relay");
+        if(isInput)
+            channelNames.add("Relay");
         // TEST
 
         auto isDeviceEnabled = [this, isInput] (int index)

--- a/modules/tracktion_engine/playback/tracktion_DeviceManager.h
+++ b/modules/tracktion_engine/playback/tracktion_DeviceManager.h
@@ -182,9 +182,11 @@ public:
 
     Engine& engine;
 
-    // TEST
+    // BEATCONNECT MODIFICATION START (RELAY)
     std::function<void(juce::AudioBuffer<float>&)> realyBufferProcessor;
-    // TEST
+    bool m_EnableRealy = false;
+    void enableRelay(bool p_Enable);
+    // BEATCONNECT MODIFICATION END (RELAY)
 
 private:
     struct WaveDeviceList;

--- a/modules/tracktion_engine/playback/tracktion_DeviceManager.h
+++ b/modules/tracktion_engine/playback/tracktion_DeviceManager.h
@@ -183,7 +183,8 @@ public:
     Engine& engine;
 
     // BEATCONNECT MODIFICATION START (RELAY)
-    std::function<void(juce::AudioBuffer<float>&)> realyBufferProcessor;
+    std::function<void(juce::AudioBuffer<float>&)> relayBufferProcessor;
+    std::mutex m_muRelayCallback;
     bool m_EnableRealy = false;
     void enableRelay(bool p_Enable);
     // BEATCONNECT MODIFICATION END (RELAY)

--- a/modules/tracktion_engine/playback/tracktion_DeviceManager.h
+++ b/modules/tracktion_engine/playback/tracktion_DeviceManager.h
@@ -182,6 +182,10 @@ public:
 
     Engine& engine;
 
+    // TEST
+    std::function<void(juce::AudioBuffer<float>&)> realyBufferProcessor;
+    // TEST
+
 private:
     struct WaveDeviceList;
     struct ContextDeviceClearer;


### PR DESCRIPTION
Modifications main done on creating a Relay input using the existing WaveInputDevice.
Audio from the Relay is injected via a callback set in the BC Sequencer.
Note that there is a mutex before a calling the callback function.
However, it is only used during the shutdown of the sequencer and does not affect the audio performance.