### PR TITLE
Missing samples in record relay

### DIFF
--- a/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
+++ b/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
@@ -1067,8 +1067,8 @@ public:
 
             if (nullptr != edit.engine.getDeviceManager().relayBufferProcessor)
             {
-                bool isReady = (recordingContext != nullptr && recordingContext->adjustSamples <= numSamples);
-                edit.engine.getDeviceManager().relayBufferProcessor(inputBuffer, numSamples, isReady);
+                bool isNotReady = (recordingContext != nullptr && recordingContext->adjustSamples >= numSamples);
+                edit.engine.getDeviceManager().relayBufferProcessor(inputBuffer, numSamples, !isNotReady);
             }
 
             return;
@@ -1186,7 +1186,9 @@ public:
                         // BEATCONNECT MODIFICATION START (RELAY)
                         auto& wi = getWaveInput();
                         if (wi.getIsRelay())
+                        {
                             addBlockToRecord(inputBuffer, 0, numSamples);
+                        }
                         else
                         {
                         // BEATCONNECT MODIFICATION START (RELAY)

--- a/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
+++ b/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
@@ -1197,7 +1197,7 @@ public:
 
                         // BEATCONNECT MODIFICATION START (RELAY)
                         }
-                        // BEATCONNECT MODIFICATION START (RELAY)
+                        // BEATCONNECT MODIFICATION END (RELAY)
 
                         recordingContext->adjustSamples = 0;
                     }

--- a/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
+++ b/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
@@ -1067,8 +1067,8 @@ public:
 
             if (nullptr != edit.engine.getDeviceManager().relayBufferProcessor)
             {
-                bool isNotReady = (recordingContext != nullptr && recordingContext->adjustSamples >= numSamples);
-                edit.engine.getDeviceManager().relayBufferProcessor(inputBuffer, numSamples, !isNotReady);
+                bool isReady = (recordingContext != nullptr && recordingContext->adjustSamples < numSamples);
+                edit.engine.getDeviceManager().relayBufferProcessor(inputBuffer, numSamples, isReady);
             }
 
             return;

--- a/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
+++ b/modules/tracktion_engine/playback/devices/tracktion_WaveInputDevice.cpp
@@ -1061,16 +1061,15 @@ public:
         // BEATCONNECT MODIFICATION START (RELAY)
         if (wi.getIsRelay() && wi.isEnabled())
         {
-            // Reset the size to 0.
-            // realyBufferProcessor will set the correct size.
-            inputBuffer.setSize(inputBuffer.getNumChannels(), 0, false, true);
-
             // relayBufferProcessor is a shared resource.
             // This callback function will be set to nullptr when the Relay disconnects or the application is closed.
             std::unique_lock<std::mutex> lock(edit.engine.getDeviceManager().m_muRelayCallback);
 
             if (nullptr != edit.engine.getDeviceManager().relayBufferProcessor)
-                edit.engine.getDeviceManager().relayBufferProcessor(inputBuffer);
+            {
+                bool isReady = (recordingContext != nullptr && recordingContext->adjustSamples <= numSamples);
+                edit.engine.getDeviceManager().relayBufferProcessor(inputBuffer, numSamples, isReady);
+            }
 
             return;
         }
@@ -1101,44 +1100,25 @@ public:
         CRASH_TRACER
         copyIncomingDataIntoBuffer (allChannels, numChannels, numSamples);
 
-        // BEATCONNECT MODIFICATION START (RELAY)
-        auto& wi = getWaveInput();
-        if (wi.getIsRelay())
+        auto inputGainDb = getWaveInput().inputGainDb;
+
+        if (inputGainDb > 0.01f || inputGainDb < -0.01f)
+            inputBuffer.applyGain(0, numSamples, dbToGain(inputGainDb));
+
+        if (measurerToUpdate != nullptr)
+            measurerToUpdate->processBuffer(inputBuffer, 0, numSamples);
+
+        if (retrospectiveBuffer != nullptr)
         {
-            // This could be the case where the read index catches up the the write.
-            // In this case, won't don't want to do anything.
-            if (inputBuffer.getNumSamples() == 0)
-                return;
-
-            numSamples = inputBuffer.getNumSamples();
-        }
-        else
-        {
-        // BEATCONNECT MODIFICATION END (RELAY)
-
-            auto inputGainDb = getWaveInput().inputGainDb;
-
-            if (inputGainDb > 0.01f || inputGainDb < -0.01f)
-                inputBuffer.applyGain(0, numSamples, dbToGain(inputGainDb));
-
-            if (measurerToUpdate != nullptr)
-                measurerToUpdate->processBuffer(inputBuffer, 0, numSamples);
-
-            if (retrospectiveBuffer != nullptr)
+            if (addToRetrospective)
             {
-                if (addToRetrospective)
-                {
-                    retrospectiveBuffer->updateSizeIfNeeded(inputBuffer.getNumChannels(),
-                        edit.engine.getDeviceManager().getSampleRate());
-                    retrospectiveBuffer->processBuffer(streamTime, inputBuffer, numSamples);
-                }
-
-                retrospectiveBuffer->syncToEdit(edit, context, streamTime, numSamples);
+                retrospectiveBuffer->updateSizeIfNeeded(inputBuffer.getNumChannels(),
+                    edit.engine.getDeviceManager().getSampleRate());
+                retrospectiveBuffer->processBuffer(streamTime, inputBuffer, numSamples);
             }
 
-        // BEATCONNECT MODIFICATION START (RELAY)
+            retrospectiveBuffer->syncToEdit(edit, context, streamTime, numSamples);
         }
-        // BEATCONNECT MODIFICATION END (RELAY)
 
         {
             const juce::ScopedLock sl(consumerLock);
@@ -1203,7 +1183,20 @@ public:
                     }
                     else
                     {
-                        addBlockToRecord (inputBuffer, adjustSamples, numSamples - adjustSamples);
+                        // BEATCONNECT MODIFICATION START (RELAY)
+                        auto& wi = getWaveInput();
+                        if (wi.getIsRelay())
+                            addBlockToRecord(inputBuffer, 0, numSamples);
+                        else
+                        {
+                        // BEATCONNECT MODIFICATION START (RELAY)
+
+                            addBlockToRecord(inputBuffer, adjustSamples, numSamples - adjustSamples);
+
+                        // BEATCONNECT MODIFICATION START (RELAY)
+                        }
+                        // BEATCONNECT MODIFICATION START (RELAY)
+
                         recordingContext->adjustSamples = 0;
                     }
                 }

--- a/modules/tracktion_engine/playback/tracktion_DeviceManager.h
+++ b/modules/tracktion_engine/playback/tracktion_DeviceManager.h
@@ -183,7 +183,7 @@ public:
     Engine& engine;
 
     // BEATCONNECT MODIFICATION START (RELAY)
-    std::function<void(juce::AudioBuffer<float>&)> relayBufferProcessor;
+    std::function<void(juce::AudioBuffer<float>&, int, bool)> relayBufferProcessor;
     std::mutex m_muRelayCallback;
     bool m_EnableRealy = false;
     void enableRelay(bool p_Enable);


### PR DESCRIPTION
This is to address the delay between the start of the recording and the relay input buffer.
The trick is not to start the transfer of the relay buffer into the relay input buffer until the recording is ready.
Ready meaning that there is an "adjustment" sample count with tracktion. The recording won't start till that count reaches 0.