### PR TITLE
962-Add "isInstrument" property to PLUGIN in edit

### DIFF
--- a/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
+++ b/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
@@ -993,9 +993,9 @@ Plugin::Ptr PluginCache::createNewPlugin (const juce::String& type, const juce::
 
     const juce::ScopedLock sl (lock);
     auto p = addPluginToCache (edit.engine.getPluginManager().createNewPlugin (edit, type, desc));
+    // BEATCONNECT MODIFICATIONS START
     p.get()->state.setProperty(IDs::isInstrument, desc.isInstrument, nullptr);
 
-    // BEATCONNECT MODIFICATIONS START
     if (p.get()->getPluginType() == type) {
         // p.get()->state.setProperty(IDs::uniqueId, p.get()->getUniqueId(), nullptr);
     }

--- a/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
+++ b/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
@@ -724,8 +724,6 @@ Plugin::Ptr PluginManager::createNewPlugin (Edit& ed, const juce::String& type, 
                 IDs::name, desc.name
             );
 
-
-
             if (ed.engine.getPluginManager().areGUIsLockedByDefault())
                 v.setProperty (IDs::windowLocked, true, nullptr);
 
@@ -774,7 +772,7 @@ void PluginManager::addInitialSamplerDrumPadValueTree(juce::ValueTree& v)
             return IDs::Tambourine.toString();
         }
         else if (i >= 4 && i <= 7) {
-            return IDs::Cymbol.toString();
+            return IDs::Cymbal.toString();
         }
         else if (i >= 8 && i <= 11) {
             return IDs::Snare.toString();
@@ -978,8 +976,7 @@ Plugin::Ptr PluginCache::createNewPlugin (const juce::ValueTree& v)
     auto p = addPluginToCache (edit.engine.getPluginManager().createNewPlugin (edit, v));
 
     // BEATCONNECT MODIFICATIONS START
-    std::string test = p.get()->getPluginType().toStdString();
-    if (p.get()->getPluginType() == v.getType().toString()) { // untested
+    if (p.get()->getPluginType() == v.getType().toString()) {
         // p.get()->state.setProperty(IDs::uniqueId, p.get()->getUniqueId(), nullptr);
     }
     // BEATCONNECT MODIFICATIONS START
@@ -996,9 +993,9 @@ Plugin::Ptr PluginCache::createNewPlugin (const juce::String& type, const juce::
 
     const juce::ScopedLock sl (lock);
     auto p = addPluginToCache (edit.engine.getPluginManager().createNewPlugin (edit, type, desc));
+    p.get()->state.setProperty(IDs::isInstrument, desc.isInstrument, nullptr);
 
     // BEATCONNECT MODIFICATIONS START
-    std::string test = p.get()->getPluginType().toStdString();
     if (p.get()->getPluginType() == type) {
         // p.get()->state.setProperty(IDs::uniqueId, p.get()->getUniqueId(), nullptr);
     }

--- a/modules/tracktion_engine/utilities/tracktion_Identifiers.h
+++ b/modules/tracktion_engine/utilities/tracktion_Identifiers.h
@@ -646,20 +646,21 @@ namespace IDs
     DECLARE_ID (resamplingQuality)
 
     // BEATCONNECT MODIFICATIONS START HERE
-    DECLARE_ID(SamplerDrumPad)
-    DECLARE_ID(Tambourine)
-    DECLARE_ID(Cymbol)
-    DECLARE_ID(Snare)
-    DECLARE_ID(Kick)
-    DECLARE_ID(PluginParameters)
-    DECLARE_ID(PluginParameter)
-    DECLARE_ID(paramId)
+    DECLARE_ID(Cymbal)
     DECLARE_ID(defaultValue)
-    DECLARE_ID(minimumValue)
-    DECLARE_ID(maximumValue)
     DECLARE_ID(Faceplate)
-    DECLARE_ID(RecordingMidiClip)
+    DECLARE_ID(isInstrument)
+    DECLARE_ID(Kick)
+    DECLARE_ID(maximumValue)
+    DECLARE_ID(minimumValue)
+    DECLARE_ID(paramId)
     DECLARE_ID(PatternChannel)
+    DECLARE_ID(PluginParameter)
+    DECLARE_ID(PluginParameters)
+    DECLARE_ID(RecordingMidiClip)
+    DECLARE_ID(SamplerDrumPad)
+    DECLARE_ID(Snare)
+    DECLARE_ID(Tambourine)
     // BEATCONNECT MODIFICATIONS END HERE
 
     #undef DECLARE_ID


### PR DESCRIPTION
Change to the createNewPlugin flow to add the property `isInstrument` to plugin ValueTrees.