### PR TITLE
988: drum machine additions - Tremolo and KeyNoteOffset 

### DIFF
--- a/modules/tracktion_engine/model/clips/tracktion_StepClip.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_StepClip.cpp
@@ -399,11 +399,17 @@ void StepClip::generateMidiSequenceForChannels (juce::MidiMessageSequence& resul
 
                         const float channelVelScale = c.noteValue / 127.0f;
                         const float vel = cache->getVelocity (i) / 127.0f;
-                        int note = c.noteNumber + cache->getKeyNoteOffset(i);
+                        int note = c.noteNumber;
 
                         jassert (c.channel.get().isValid());
                         auto chan = c.channel.get().getChannelNumber();
+                        
 
+                        // BEATCONNECT MODIFICATION START
+                        const float pitchWheelRange = 25.0;
+                        float pitchWheel = juce::MidiMessage::pitchbendToPitchwheelPos(i, pitchWheelRange); 
+                        result.addEvent (juce::MidiMessage::pitchWheel(chan, pitchWheel), eventStart);
+                        // BEATCONNECT MODIFICATION END
                         result.addEvent (juce::MidiMessage::noteOn  (chan, note, vel * channelVelScale), eventStart);
                         result.addEvent (juce::MidiMessage::noteOff (chan, note, (uint8_t) juce::jlimit (0, 127, c.noteValue.get())), eventEnd);
                         

--- a/modules/tracktion_engine/model/clips/tracktion_StepClip.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_StepClip.cpp
@@ -399,6 +399,9 @@ void StepClip::generateMidiSequenceForChannels (juce::MidiMessageSequence& resul
 
                         const float channelVelScale = c.noteValue / 127.0f;
                         const float vel = cache->getVelocity (i) / 127.0f;
+                        // BEATCONNECT MODIFICATION START
+                        const int tremoloAttacks = cache->getTremolo(i);
+                        // BEATCONNECT MODIFICATION END
                         jassert (c.channel.get().isValid());
                         auto chan = c.channel.get().getChannelNumber();
                         result.addEvent (juce::MidiMessage::noteOn  (chan, c.noteNumber, vel * channelVelScale), eventStart);
@@ -441,6 +444,14 @@ void StepClip::generateMidiSequence (juce::MidiMessageSequence& result,
 
             generateMidiSequenceForChannels (result, convertToSeconds, p->getPattern(), startBeat,
                                              clipStartBeat, clipEndBeat, tempoSequence);
+
+            // =8>
+            for (auto element : result)
+            {
+                auto test = element->message.getFloatVelocity();
+                element->message.setVelocity(0.1);
+            }
+            // =8>
 
             if (instance != nullptr)
             {

--- a/modules/tracktion_engine/model/clips/tracktion_StepClip.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_StepClip.cpp
@@ -404,13 +404,12 @@ void StepClip::generateMidiSequenceForChannels (juce::MidiMessageSequence& resul
                         jassert (c.channel.get().isValid());
                         auto chan = c.channel.get().getChannelNumber();
                         
-
                         // BEATCONNECT MODIFICATION START
-                        const float pitchWheelRange = 25.0;
-                        float pitchWheel = juce::MidiMessage::pitchbendToPitchwheelPos(i, pitchWheelRange); 
-                        result.addEvent (juce::MidiMessage::pitchWheel(chan, pitchWheel), eventStart);
+                        const float pitchWheelSemitoneRange = 12.0;
+                        float pitchWheelPosition = juce::MidiMessage::pitchbendToPitchwheelPos(cache->getKeyNoteOffset(i), pitchWheelSemitoneRange);
+                        result.addEvent (juce::MidiMessage::pitchWheel(chan, pitchWheelPosition), eventStart);
                         // BEATCONNECT MODIFICATION END
-                        result.addEvent (juce::MidiMessage::noteOn  (chan, note, vel * channelVelScale), eventStart);
+                        result.addEvent (juce::MidiMessage::noteOn (chan, note, vel * channelVelScale), eventStart);
                         result.addEvent (juce::MidiMessage::noteOff (chan, note, (uint8_t) juce::jlimit (0, 127, c.noteValue.get())), eventEnd);
                         
                         // BEATCONNECT MODIFICATION START

--- a/modules/tracktion_engine/model/clips/tracktion_StepClip.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_StepClip.cpp
@@ -399,11 +399,13 @@ void StepClip::generateMidiSequenceForChannels (juce::MidiMessageSequence& resul
 
                         const float channelVelScale = c.noteValue / 127.0f;
                         const float vel = cache->getVelocity (i) / 127.0f;
+                        int note = c.noteNumber + cache->getKeyNoteOffset(i);
 
                         jassert (c.channel.get().isValid());
                         auto chan = c.channel.get().getChannelNumber();
-                        result.addEvent (juce::MidiMessage::noteOn  (chan, c.noteNumber, vel * channelVelScale), eventStart);
-                        result.addEvent (juce::MidiMessage::noteOff (chan, c.noteNumber, (uint8_t) juce::jlimit (0, 127, c.noteValue.get())), eventEnd);
+
+                        result.addEvent (juce::MidiMessage::noteOn  (chan, note, vel * channelVelScale), eventStart);
+                        result.addEvent (juce::MidiMessage::noteOff (chan, note, (uint8_t) juce::jlimit (0, 127, c.noteValue.get())), eventEnd);
                         
                         // BEATCONNECT MODIFICATION START
                         int tremoloAttacks = cache->getTremolo(i);
@@ -415,8 +417,8 @@ void StepClip::generateMidiSequenceForChannels (juce::MidiMessageSequence& resul
                             for (int i = 1; i < totalAttacks; i++) {
                                 float attackTimeOffset = i * attackInterval;
                                 float newEventStart = eventStart + attackTimeOffset;
-                                result.addEvent(juce::MidiMessage::noteOn(chan, c.noteNumber, vel * channelVelScale), newEventStart);
-                                result.addEvent(juce::MidiMessage::noteOff(chan, c.noteNumber, (uint8_t)juce::jlimit(0, 127, c.noteValue.get())), newEventStart + attackInterval);
+                                result.addEvent(juce::MidiMessage::noteOn(chan, note, vel * channelVelScale), newEventStart);
+                                result.addEvent(juce::MidiMessage::noteOff(chan, note, (uint8_t)juce::jlimit(0, 127, c.noteValue.get())), newEventStart + attackInterval);
                             }
                         }
                         // BEATCONNECT MODIFICATION END

--- a/modules/tracktion_engine/model/clips/tracktion_StepClip.h
+++ b/modules/tracktion_engine/model/clips/tracktion_StepClip.h
@@ -95,10 +95,10 @@ public:
         void setNoteLength (BeatDuration);
 
         // BEATCONNECT MODIFICATON START
-        int getPitch(int channel, int index) const;
-        juce::Array<int> getPitches(int channel) const;
-        void setPitch(int channel, int index, int value);
-        void setPitches(int channel, const juce::Array<int>& values);
+        int getKeyNoteOffset(int channel, int index) const;
+        juce::Array<int> getKeyNoteOffsets(int channel) const;
+        void setKeyNoteOffset(int channel, int index, int value);
+        void setKeyNoteOffsets(int channel, const juce::Array<int>& values);
 
         int getTremolo (int channel, int index) const;
         juce::Array<int> getTremolos(int channel) const;
@@ -135,7 +135,7 @@ public:
             int getVelocity (int index) const noexcept;
             double getGate (int index) const noexcept;
             // BEATCONNECT MODIFICATION START
-            int getPitch(int index) const noexcept;
+            int getKeyNoteOffset(int index) const noexcept;
             // BEATCONNECT MODIFICATION END
             float getProbability (int index) const noexcept;
             // BEATCONNECT MODIFICATION START
@@ -146,7 +146,7 @@ public:
             juce::Array<int> velocities;
             juce::Array<double> gates;
             // BEATCONNECT MODIFICATION START
-            juce::Array<int> pitches;
+            juce::Array<int> keyNoteOffsets;
             // BEATCONNECT MODIFICATION END
             juce::Array<float> probabilities;
             // BEATCONNECT MODIFICATION START
@@ -195,6 +195,9 @@ public:
     //==============================================================================
     enum Defaults
     {
+        // BEATCONNECT MODIFICATIONS START
+        defaultKeyNoteOffset = 0,
+        // BEATCONNECT MODIFICATIONS END
         defaultNumNotes     = 16,
         // BEATCONNECT MODIFICATIONS START
         defaultNumChannels  = 16,
@@ -202,10 +205,15 @@ public:
         defaultMidiChannel  = 1,
         defaultNoteNumber   = 60,
         // BEATCONNECT MODIFICATIONS START
-        defaultPitchOffset = 0,
         defaultTremoloAttacks = 0,
         // BEATCONNECT MODIFICATIONS END
         defaultNoteValue    = 96,
+
+        // BEATCONNECT MODIFICATIONS START
+        // Midi only has 127 available notes, guaranteed to be out of range.
+        errorKeyNoteOffset  = -127,
+        errorTremoloAttacks = -1,
+        // BEATCONNECT MODIFICATIONS END
 
         minNumNotes         = 2,
         maxNumNotes         = 512,
@@ -214,7 +222,7 @@ public:
         maxNumChannels      = 60
 
         // BEATCONNECT MODIFICATIONS START
-        ,maxTremoloAttacks  = 8
+        , maxTremoloAttacks = 8
         // BEATCONNECT MODIFICATIONS END
     };
 

--- a/modules/tracktion_engine/model/clips/tracktion_StepClip.h
+++ b/modules/tracktion_engine/model/clips/tracktion_StepClip.h
@@ -94,6 +94,14 @@ public:
         /** Sets the length of one step as a fraction of a beat. */
         void setNoteLength (BeatDuration);
 
+        // BEATCONNECT MODIFICATON START
+        int getTremolo (int channel, int index) const;
+        juce::Array<int> getTremolos(int channel) const;
+        void setTremolo(int channel, int index, unsigned int value);
+        void setTremolos(int channel, const juce::Array<int>& values);
+        
+        // BEATCONNECT MODIFICATON END
+
         juce::Array<int> getVelocities (int channel) const;
         void setVelocities (int channel, const juce::Array<int>&);
 
@@ -122,12 +130,24 @@ public:
             bool getNote (int index) const noexcept;
             int getVelocity (int index) const noexcept;
             double getGate (int index) const noexcept;
+            // BEATCONNECT MODIFICATION START
+            int getPitch(int index) const noexcept;
+            // BEATCONNECT MODIFICATION END
             float getProbability (int index) const noexcept;
+            // BEATCONNECT MODIFICATION START
+            int getTremolo(int index) const noexcept;
+            // BEATCONNECT MODIFICATION END
 
             juce::BigInteger notes;
             juce::Array<int> velocities;
             juce::Array<double> gates;
+            // BEATCONNECT MODIFICATION START
+            juce::Array<int> pitches;
+            // BEATCONNECT MODIFICATION END
             juce::Array<float> probabilities;
+            // BEATCONNECT MODIFICATION START
+            juce::Array<int> tremolos;
+            // BEATCONNECT MODIFICATION END
             JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (CachedPattern)
         };
 
@@ -177,6 +197,10 @@ public:
         // BEATCONNECT MODIFICATIONS END
         defaultMidiChannel  = 1,
         defaultNoteNumber   = 60,
+        // BEATCONNECT MODIFICATIONS START
+        defaultPitchOffset = 0,
+        defaultTremoloAttacks = 0,
+        // BEATCONNECT MODIFICATIONS END
         defaultNoteValue    = 96,
 
         minNumNotes         = 2,

--- a/modules/tracktion_engine/model/clips/tracktion_StepClip.h
+++ b/modules/tracktion_engine/model/clips/tracktion_StepClip.h
@@ -97,9 +97,8 @@ public:
         // BEATCONNECT MODIFICATON START
         int getTremolo (int channel, int index) const;
         juce::Array<int> getTremolos(int channel) const;
-        void setTremolo(int channel, int index, unsigned int value);
+        void setTremolo(int channel, int index, int value);
         void setTremolos(int channel, const juce::Array<int>& values);
-        
         // BEATCONNECT MODIFICATON END
 
         juce::Array<int> getVelocities (int channel) const;
@@ -208,6 +207,10 @@ public:
 
         minNumChannels      = 1,
         maxNumChannels      = 60
+
+        // BEATCONNECT MODIFICATIONS START
+        ,maxTremoloAttacks  = 8
+        // BEATCONNECT MODIFICATIONS END
     };
 
     //==============================================================================

--- a/modules/tracktion_engine/model/clips/tracktion_StepClip.h
+++ b/modules/tracktion_engine/model/clips/tracktion_StepClip.h
@@ -95,6 +95,11 @@ public:
         void setNoteLength (BeatDuration);
 
         // BEATCONNECT MODIFICATON START
+        int getPitch(int channel, int index) const;
+        juce::Array<int> getPitches(int channel) const;
+        void setPitch(int channel, int index, int value);
+        void setPitches(int channel, const juce::Array<int>& values);
+
         int getTremolo (int channel, int index) const;
         juce::Array<int> getTremolos(int channel) const;
         void setTremolo(int channel, int index, int value);

--- a/modules/tracktion_engine/model/clips/tracktion_StepClipPattern.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_StepClipPattern.cpp
@@ -176,11 +176,29 @@ void StepClip::Pattern::setNote (int channel, int index, bool value)
 
             if (getGate (channel, index) == 0.0)
                 setGate (channel, index, 1.0);
+
+            if (getTremolo(channel, index) == 0)
+                setTremolo(channel, index, defaultTremoloAttacks);
         }
     }
 }
 
 // BEATCONNECT MODIFICATION START
+int StepClip::Pattern::getPitch(int channel, int index) const {
+    if (!getNote(channel, index))
+        return -1;
+
+    auto pitches = getTremolos(channel);
+
+    if (juce::isPositiveAndBelow(index, pitches.size()))
+        return pitches[index];
+
+    if (clip.getChannels()[channel] != nullptr)
+        return defaultPitchOffset;
+
+    return -127; // Midi only has 127 available notes, guaranteed to be out of range.
+}
+
 int StepClip::Pattern::getTremolo(int channel, int index) const {
     if (!getNote (channel, index))
         return -1;
@@ -215,6 +233,9 @@ void StepClip::Pattern::setTremolo(int channel, int index, int value) {
 
     auto tremolos = getTremolos(channel);
     const int size = tremolos.size();
+
+    if (!juce::isPositiveAndNotGreaterThan(index, size))
+        tremolos.insertMultiple(size, 0, index - size);
 
     tremolos.set(index, value);
     setTremolos(channel, tremolos);

--- a/modules/tracktion_engine/model/clips/tracktion_StepClipPattern.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_StepClipPattern.cpp
@@ -182,7 +182,6 @@ void StepClip::Pattern::setNote (int channel, int index, bool value)
 
 // BEATCONNECT MODIFICATION START
 int StepClip::Pattern::getTremolo(int channel, int index) const {
-
     if (!getNote (channel, index))
         return -1;
 
@@ -208,7 +207,7 @@ juce::Array<int> StepClip::Pattern::getTremolos(int channel) const {
     return tremolos;
 }
 
-void StepClip::Pattern::setTremolo(int channel, int index, unsigned int value) {
+void StepClip::Pattern::setTremolo(int channel, int index, int value) {
     if (!juce::isPositiveAndBelow(channel, (int)maxNumChannels))
         return; // Out of range
 
@@ -216,9 +215,6 @@ void StepClip::Pattern::setTremolo(int channel, int index, unsigned int value) {
 
     auto tremolos = getTremolos(channel);
     const int size = tremolos.size();
-
-    if (!juce::isPositiveAndNotGreaterThan(index, size))
-        tremolos.insertMultiple(size, 127, index - size);
 
     tremolos.set(index, value);
     setTremolos(channel, tremolos);
@@ -239,7 +235,7 @@ void StepClip::Pattern::setTremolos(int channel, const juce::Array<int>& values)
     for (int element : values)
         stringArray.add(juce::String(element));
 
-    state.getChild(channel).setProperty(IDs::velocities, stringArray.joinIntoString(" "), clip.getUndoManager());
+    state.getChild(channel).setProperty(IDs::tremolos, stringArray.joinIntoString(" "), clip.getUndoManager());
 }
 // BEATCONNECT MODIFICATION END
 
@@ -411,6 +407,9 @@ StepClip::Pattern::CachedPattern::CachedPattern (const Pattern& p, int c)
       velocities (p.getVelocities (c)),
       gates (p.getGates (c)),
       probabilities (p.getProbabilities (c))
+      // BEATCONNECT MODIFICATION START
+      , tremolos (p.getTremolos(c))
+      // BEATCONNECT MODIFICATION END
 {
 }
 

--- a/modules/tracktion_engine/model/clips/tracktion_StepClipPattern.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_StepClipPattern.cpp
@@ -472,6 +472,9 @@ StepClip::Pattern::CachedPattern::CachedPattern (const Pattern& p, int c)
     : notes (p.getChannel (c)),
       velocities (p.getVelocities (c)),
       gates (p.getGates (c)),
+      // BEATCONNECT MODIFICATION START
+      keyNoteOffsets (p.getKeyNoteOffsets(c)),
+      // BEATCONNECT MODIFICATION END
       probabilities (p.getProbabilities (c))
       // BEATCONNECT MODIFICATION START
       , tremolos (p.getTremolos(c))

--- a/modules/tracktion_engine/playback/graph/tracktion_EditNodeBuilder.cpp
+++ b/modules/tracktion_engine/playback/graph/tracktion_EditNodeBuilder.cpp
@@ -679,7 +679,6 @@ std::unique_ptr<tracktion::graph::Node> createNodeForStepClip (StepClip& clip, c
     for (int i = clip.usesProbability() ? 64 : 1; --i >= 0;)
     {
         juce::MidiMessageSequence sequence;
-
         clip.generateMidiSequence (sequence);
         sequences.push_back (sequence);
     }

--- a/modules/tracktion_engine/playback/graph/tracktion_EditNodeBuilder.cpp
+++ b/modules/tracktion_engine/playback/graph/tracktion_EditNodeBuilder.cpp
@@ -679,6 +679,7 @@ std::unique_ptr<tracktion::graph::Node> createNodeForStepClip (StepClip& clip, c
     for (int i = clip.usesProbability() ? 64 : 1; --i >= 0;)
     {
         juce::MidiMessageSequence sequence;
+
         clip.generateMidiSequence (sequence);
         sequences.push_back (sequence);
     }

--- a/modules/tracktion_engine/plugins/effects/tracktion_SamplerPlugin.cpp
+++ b/modules/tracktion_engine/plugins/effects/tracktion_SamplerPlugin.cpp
@@ -311,8 +311,9 @@ void SamplerPlugin::applyToBuffer (const PluginRenderContext& fc)
 
                 if (m.isNoteOn())
                 {
-                   
+                    // BEATCONNECT MODIFICATION START
                     int note = m.getNoteNumber();
+                    // BEATCONNECT MODIFICATION END
                     const int noteTimeSample = juce::roundToInt (m.getTimeStamp() * sampleRate);
 
                     for (auto playingNote : playingNotes)
@@ -333,19 +334,22 @@ void SamplerPlugin::applyToBuffer (const PluginRenderContext& fc)
                             && ss->audioData.getNumSamples() > 0
                             && playingNotes.size() < maximumSimultaneousNotes)
                         {
-
+                        // BEATCONNECT MODIFICATION START
                         if (fc.bufferForMidiMessages->size() > 1 && (&m - 1)->isPitchWheel()) {
-                            const float pitchWheel = (&m - 1)->getPitchWheelValue();
-                            const float sampleRate = 440.0;
+                            const float pitchWheelPosition = (&m - 1)->getPitchWheelValue();
+                            const float sampleRateHz = 440.0;
                             const int midiPitchWheelBase = 0x2000;
                             const float semitonesPerOctave = 12.0;
-                            const float pitchWheelRange = 25.0;
-                            double noteHz = sampleRate * std::pow(2.0, (ss->keyNote - 69.0) / semitonesPerOctave);
-
-                            auto newNoteHz = noteHz * pow(2.0, ((pitchWheel - midiPitchWheelBase) * pitchWheelRange)/(semitonesPerOctave * midiPitchWheelBase));
+                            const float pitchWheelSemitoneRange = 12.0;
+                            const float A440asMidiNote = 69.0;
+                            
+                            // Given the variables keyNote, pitchWheelPosition, and pitchWheelSemitoneRange,
+                            // and given system constants, solve for the new note values
+                            double noteHz = sampleRateHz * std::pow(2.0, (ss->keyNote - A440asMidiNote) / semitonesPerOctave); // TODO =8> factor this
+                            auto newNoteHz = noteHz * pow(2.0, ((pitchWheelPosition - midiPitchWheelBase) * pitchWheelSemitoneRange)/(semitonesPerOctave * midiPitchWheelBase)); // TODO =8> factor this
                             note = frequencyToMidiNote(newNoteHz);
                         }
-
+                        // BEATCONNECT MODIFICATION END
                             highlightedNotes.setBit (note);
                             playingNotes.add (new SampledNote (note,
                                                                ss->keyNote,

--- a/modules/tracktion_engine/plugins/effects/tracktion_SamplerPlugin.cpp
+++ b/modules/tracktion_engine/plugins/effects/tracktion_SamplerPlugin.cpp
@@ -337,7 +337,7 @@ void SamplerPlugin::applyToBuffer (const PluginRenderContext& fc)
                         // BEATCONNECT MODIFICATION START
                         if (fc.bufferForMidiMessages->size() > 1 && (&m - 1)->isPitchWheel()) {
                             const float pitchWheelPosition = (&m - 1)->getPitchWheelValue();
-                            const float sampleRateHz = 440.0;
+                            const float midiCalibriationHz = 440.0;
                             const int midiPitchWheelBase = 0x2000;
                             const float semitonesPerOctave = 12.0;
                             const float pitchWheelSemitoneRange = 12.0;
@@ -345,7 +345,7 @@ void SamplerPlugin::applyToBuffer (const PluginRenderContext& fc)
                             
                             // Given the variables keyNote, pitchWheelPosition, and pitchWheelSemitoneRange,
                             // and given system constants, solve for the new note values
-                            double noteHz = sampleRateHz * std::pow(2.0, (ss->keyNote - A440asMidiNote) / semitonesPerOctave); // TODO =8> factor this
+                            double noteHz = midiCalibriationHz * std::pow(2.0, (ss->keyNote - A440asMidiNote) / semitonesPerOctave); // TODO =8> factor this
                             auto newNoteHz = noteHz * pow(2.0, ((pitchWheelPosition - midiPitchWheelBase) * pitchWheelSemitoneRange)/(semitonesPerOctave * midiPitchWheelBase)); // TODO =8> factor this
                             note = frequencyToMidiNote(newNoteHz);
                         }

--- a/modules/tracktion_engine/utilities/tracktion_Identifiers.h
+++ b/modules/tracktion_engine/utilities/tracktion_Identifiers.h
@@ -658,8 +658,8 @@ namespace IDs
     DECLARE_ID(RecordingMidiClip)
     
     // Sampler IDs
-    DECLARE_ID(pitchOffset)
-    DECLARE_ID(pitchOffsets)
+    DECLARE_ID(keyNoteOffset)
+    DECLARE_ID(keyNoteOffsets)
     DECLARE_ID(tremolo)
     DECLARE_ID(tremolos)
 

--- a/modules/tracktion_engine/utilities/tracktion_Identifiers.h
+++ b/modules/tracktion_engine/utilities/tracktion_Identifiers.h
@@ -646,20 +646,29 @@ namespace IDs
     DECLARE_ID (resamplingQuality)
 
     // BEATCONNECT MODIFICATIONS START HERE
-    DECLARE_ID(SamplerDrumPad)
-    DECLARE_ID(Tambourine)
-    DECLARE_ID(Cymbol)
-    DECLARE_ID(Snare)
-    DECLARE_ID(Kick)
-    DECLARE_ID(PluginParameters)
-    DECLARE_ID(PluginParameter)
-    DECLARE_ID(paramId)
+    // Generic IDs
     DECLARE_ID(defaultValue)
+    DECLARE_ID(Faceplate)
     DECLARE_ID(minimumValue)
     DECLARE_ID(maximumValue)
-    DECLARE_ID(Faceplate)
-    DECLARE_ID(RecordingMidiClip)
+    DECLARE_ID(paramId)
     DECLARE_ID(PatternChannel)
+    DECLARE_ID(PluginParameter)
+    DECLARE_ID(PluginParameters)
+    DECLARE_ID(RecordingMidiClip)
+    
+    // Sampler IDs
+    DECLARE_ID(pitchOffset)
+    DECLARE_ID(pitchOffsets)
+    DECLARE_ID(tremolo)
+    DECLARE_ID(tremolos)
+
+    // Drum Machine IDs
+    DECLARE_ID(Cymbol)
+    DECLARE_ID(Kick)
+    DECLARE_ID(SamplerDrumPad)
+    DECLARE_ID(Snare)
+    DECLARE_ID(Tambourine)
     // BEATCONNECT MODIFICATIONS END HERE
 
     #undef DECLARE_ID

--- a/modules/tracktion_engine/utilities/tracktion_Identifiers.h
+++ b/modules/tracktion_engine/utilities/tracktion_Identifiers.h
@@ -646,14 +646,10 @@ namespace IDs
     DECLARE_ID (resamplingQuality)
 
     // BEATCONNECT MODIFICATIONS START HERE
-    DECLARE_ID(Cymbal)
     // Generic IDs
     DECLARE_ID(defaultValue)
     DECLARE_ID(Faceplate)
-    DECLARE_ID(Faceplate)
     DECLARE_ID(isInstrument)
-    DECLARE_ID(Kick)
-    DECLARE_ID(maximumValue)
     DECLARE_ID(minimumValue)
     DECLARE_ID(maximumValue)
     DECLARE_ID(paramId)


### PR DESCRIPTION
As part of work towards the completion of this ticket: https://github.com/BeatConnect/bc_unity_daw/issues/988
Please review in conjunction with DLL changes: https://github.com/BeatConnect/bc_unity_daw/pull/1010

## Description
Engine changes to support tremolos and keyNoteOffsets on pattern channels. The changes are intended to be preliminary and improvements in readability and organisation are to come.

## Testing
This PR has enjoyed only light functional testing so far, any and all feedback and comments are welcome. 