### PR TITLE
988 - Add Drum Machine type - Use it in Client Code

### DIFF
--- a/modules/tracktion_engine/model/clips/tracktion_StepClip.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_StepClip.cpp
@@ -8,6 +8,10 @@
     Tracktion Engine uses a GPL/commercial licence - see LICENCE.md for details.
 */
 
+// BEATCONNECT MODIFICATION START
+#include "../Source/Plugin/DrumMachinePlugin.h"
+// BEATCONNECT MODIFICATION END
+
 namespace tracktion { inline namespace engine
 {
 
@@ -405,8 +409,7 @@ void StepClip::generateMidiSequenceForChannels (juce::MidiMessageSequence& resul
                         auto chan = c.channel.get().getChannelNumber();
                         
                         // BEATCONNECT MODIFICATION START
-                        const float pitchWheelSemitoneRange = 12.0;
-                        float pitchWheelPosition = juce::MidiMessage::pitchbendToPitchwheelPos(cache->getKeyNoteOffset(i), pitchWheelSemitoneRange);
+                        float pitchWheelPosition = juce::MidiMessage::pitchbendToPitchwheelPos(cache->getKeyNoteOffset(i), DrumMachinePlugin::pitchWheelSemitoneRange);
                         result.addEvent (juce::MidiMessage::pitchWheel(chan, pitchWheelPosition), eventStart);
                         // BEATCONNECT MODIFICATION END
                         result.addEvent (juce::MidiMessage::noteOn (chan, note, vel * channelVelScale), eventStart);

--- a/modules/tracktion_engine/plugins/effects/tracktion_SamplerPlugin.cpp
+++ b/modules/tracktion_engine/plugins/effects/tracktion_SamplerPlugin.cpp
@@ -9,7 +9,7 @@
 */
 
 // BEATCONNECT MODIFICATION START
-#include "../../Data/GlobalConstants.h"
+#include "../../Data/Midi.h"
 // BEATCONNECT MODIFICATION END
 
 namespace tracktion { inline namespace engine

--- a/modules/tracktion_engine/plugins/effects/tracktion_SamplerPlugin.cpp
+++ b/modules/tracktion_engine/plugins/effects/tracktion_SamplerPlugin.cpp
@@ -8,6 +8,10 @@
     Tracktion Engine uses a GPL/commercial licence - see LICENCE.md for details.
 */
 
+// BEATCONNECT MODIFICATION START
+#include "../../Data/GlobalConstants.h"
+// BEATCONNECT MODIFICATION END
+
 namespace tracktion { inline namespace engine
 {
 
@@ -336,18 +340,16 @@ void SamplerPlugin::applyToBuffer (const PluginRenderContext& fc)
                         {
                         // BEATCONNECT MODIFICATION START
                         if (fc.bufferForMidiMessages->size() > 1 && (&m - 1)->isPitchWheel()) {
-                            const float pitchWheelPosition = (&m - 1)->getPitchWheelValue();
-                            const float midiCalibriationHz = 440.0;
-                            const int midiPitchWheelBase = 0x2000;
-                            const float semitonesPerOctave = 12.0;
-                            const float pitchWheelSemitoneRange = 12.0;
-                            const float A440asMidiNote = 69.0;
+                            const double pitchWheelPosition = (&m - 1)->getPitchWheelValue();
                             
                             // Given the variables keyNote, pitchWheelPosition, and pitchWheelSemitoneRange,
                             // and given system constants, solve for the new note values
-                            double noteHz = midiCalibriationHz * std::pow(2.0, (ss->keyNote - A440asMidiNote) / semitonesPerOctave); // TODO =8> factor this
-                            auto newNoteHz = noteHz * pow(2.0, ((pitchWheelPosition - midiPitchWheelBase) * pitchWheelSemitoneRange)/(semitonesPerOctave * midiPitchWheelBase)); // TODO =8> factor this
-                            note = frequencyToMidiNote(newNoteHz);
+                            double noteHz = BeatConnect::MidiNote::getNoteFrequency(ss->keyNote);
+                            double newNoteHz = BeatConnect::MidiNote::getFrequencyByPitchWheel(pitchWheelPosition, DrumMachinePlugin::pitchWheelSemitoneRange, noteHz);
+                            note = BeatConnect::MidiNote::getMidiNote(newNoteHz);
+                            auto ShouldBe65point406 = midiNoteToFrequency(ss->keyNote);
+                            auto ShouldBe36 = frequencyToMidiNote(newNoteHz);
+                            auto breakPoint = 1;
                         }
                         // BEATCONNECT MODIFICATION END
                             highlightedNotes.setBit (note);

--- a/modules/tracktion_engine/plugins/effects/tracktion_SamplerPlugin.cpp
+++ b/modules/tracktion_engine/plugins/effects/tracktion_SamplerPlugin.cpp
@@ -347,9 +347,6 @@ void SamplerPlugin::applyToBuffer (const PluginRenderContext& fc)
                             double noteHz = BeatConnect::MidiNote::getNoteFrequency(ss->keyNote);
                             double newNoteHz = BeatConnect::MidiNote::getFrequencyByPitchWheel(pitchWheelPosition, DrumMachinePlugin::pitchWheelSemitoneRange, noteHz);
                             note = BeatConnect::MidiNote::getMidiNote(newNoteHz);
-                            auto ShouldBe65point406 = midiNoteToFrequency(ss->keyNote);
-                            auto ShouldBe36 = frequencyToMidiNote(newNoteHz);
-                            auto breakPoint = 1;
                         }
                         // BEATCONNECT MODIFICATION END
                             highlightedNotes.setBit (note);

--- a/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
+++ b/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
@@ -730,7 +730,7 @@ Plugin::Ptr PluginManager::createNewPlugin (Edit& ed, const juce::String& type, 
                 v.setProperty (IDs::windowLocked, true, nullptr);
 
             // BEATCONNECT MODIFICATIONS START
-            if (type == "drum machine") // =8>
+            if (type == "drum machine")
                 addInitialSamplerDrumPadValueTree(v);
             // BEATCONNECT MODIFICATIONS END
 

--- a/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
+++ b/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
@@ -8,7 +8,10 @@
     Tracktion Engine uses a GPL/commercial licence - see LICENCE.md for details.
 */
 
+// BEATCONNECT MODIFICATION START
 #include "../../../../Source/Plugin/DrumMachinePlugin.h"
+// BEATCONNECT MODIFICATION END
+
 namespace tracktion { inline namespace engine
 {
 
@@ -420,7 +423,9 @@ void PluginManager::initialise()
     createBuiltInType<PitchShiftPlugin>();
     createBuiltInType<LowPassPlugin>();
     createBuiltInType<SamplerPlugin>();
-    createBuiltInType<DrumMachinePlugin>(); // =8>
+    // BEATCONNECT MODIFICATION START
+    createBuiltInType<DrumMachinePlugin>();
+    // BEATCONNECT MODIFICATION END
     createBuiltInType<FourOscPlugin>();
     createBuiltInType<MidiModifierPlugin>();
     createBuiltInType<MidiPatchBayPlugin>();
@@ -1001,7 +1006,7 @@ Plugin::Ptr PluginCache::createNewPlugin (const juce::String& type, const juce::
     if (p.get()->getPluginType() == type) {
         // p.get()->state.setProperty(IDs::uniqueId, p.get()->getUniqueId(), nullptr); // =8> To be added back in with PluginPresets: 
     }
-    // BEATCONNECT MODIFICATIONS START
+    // BEATCONNECT MODIFICATIONS END
 
     if (p != nullptr && newPluginAddedCallback != nullptr)
         newPluginAddedCallback (*p);

--- a/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
+++ b/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
@@ -8,6 +8,7 @@
     Tracktion Engine uses a GPL/commercial licence - see LICENCE.md for details.
 */
 
+#include "../../../../Source/Plugin/DrumMachinePlugin.h"
 namespace tracktion { inline namespace engine
 {
 
@@ -419,6 +420,7 @@ void PluginManager::initialise()
     createBuiltInType<PitchShiftPlugin>();
     createBuiltInType<LowPassPlugin>();
     createBuiltInType<SamplerPlugin>();
+    createBuiltInType<DrumMachinePlugin>(); // =8>
     createBuiltInType<FourOscPlugin>();
     createBuiltInType<MidiModifierPlugin>();
     createBuiltInType<MidiPatchBayPlugin>();
@@ -728,7 +730,7 @@ Plugin::Ptr PluginManager::createNewPlugin (Edit& ed, const juce::String& type, 
                 v.setProperty (IDs::windowLocked, true, nullptr);
 
             // BEATCONNECT MODIFICATIONS START
-            if (type == "sampler")
+            if (type == "drum machine") // =8>
                 addInitialSamplerDrumPadValueTree(v);
             // BEATCONNECT MODIFICATIONS END
 
@@ -997,7 +999,7 @@ Plugin::Ptr PluginCache::createNewPlugin (const juce::String& type, const juce::
     p.get()->state.setProperty(IDs::isInstrument, desc.isInstrument, nullptr);
 
     if (p.get()->getPluginType() == type) {
-        // p.get()->state.setProperty(IDs::uniqueId, p.get()->getUniqueId(), nullptr);
+        // p.get()->state.setProperty(IDs::uniqueId, p.get()->getUniqueId(), nullptr); // =8> To be added back in with PluginPresets: 
     }
     // BEATCONNECT MODIFICATIONS START
 


### PR DESCRIPTION
# Overview
https://github.com/BeatConnect/bc_unity_daw/issues/988
DLL and Interface Upgrades: https://github.com/BeatConnect/bc_unity_daw/pull/1026
Creation of a Drum Machine object to represent the BeatConnect drum machine rather than simply an instance of tracktion_SamplerPlugin. Allows differentiation between instances of DrumMachinePlugin and SamplerPlugin in the current iteration of the system, and to be the home of future code specialised for DrumMachinePlugin.

## Engine Changes
Register DrumMachinePlugin as a built in type. 

# Testing
Functional testing.