### PR TITLE
1050-Crash with tremolo set to 5

### DIFF
--- a/modules/tracktion_engine/model/clips/tracktion_StepClip.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_StepClip.cpp
@@ -410,7 +410,9 @@ void StepClip::generateMidiSequenceForChannels (juce::MidiMessageSequence& resul
                         
                         // BEATCONNECT MODIFICATION START
                         float pitchWheelPosition = juce::MidiMessage::pitchbendToPitchwheelPos(cache->getKeyNoteOffset(i), DrumMachinePlugin::pitchWheelSemitoneRange);
-                        result.addEvent (juce::MidiMessage::pitchWheel(chan, pitchWheelPosition), eventStart);
+                        if (pitchWheelPosition != BeatConnect::midiPitchWheelBase) {
+                            result.addEvent (juce::MidiMessage::pitchWheel(chan, pitchWheelPosition), eventStart);
+                        }
                         // BEATCONNECT MODIFICATION END
                         result.addEvent (juce::MidiMessage::noteOn (chan, note, vel * channelVelScale), eventStart);
                         result.addEvent (juce::MidiMessage::noteOff (chan, note, (uint8_t) juce::jlimit (0, 127, c.noteValue.get())), eventEnd);

--- a/modules/tracktion_engine/plugins/effects/tracktion_SamplerPlugin.cpp
+++ b/modules/tracktion_engine/plugins/effects/tracktion_SamplerPlugin.cpp
@@ -333,7 +333,7 @@ void SamplerPlugin::applyToBuffer (const PluginRenderContext& fc)
                             && playingNotes.size() < maximumSimultaneousNotes)
                         {
                         // BEATCONNECT MODIFICATION START
-                        if (fc.bufferForMidiMessages->size() > 1 && (&m - 1)->isPitchWheel()) {
+                        if (fc.bufferForMidiMessages->size() > 1 && &m != fc.bufferForMidiMessages->begin() && (&m - 1)->isPitchWheel()) {
                             const double pitchWheelPosition = (&m - 1)->getPitchWheelValue();
                             
                             // Given the variables keyNote, pitchWheelPosition, and pitchWheelSemitoneRange,

--- a/modules/tracktion_engine/plugins/internal/DrumMachinePlugin.h
+++ b/modules/tracktion_engine/plugins/internal/DrumMachinePlugin.h
@@ -9,7 +9,6 @@
 
 #pragma once
 
-class SamplerPlugin;
 namespace tracktion { inline namespace engine
 {
 // A Drum Machine is a specialised Sampler.


### PR DESCRIPTION
# Overview
See bc_unity_daw changes: https://github.com/BeatConnect/bc_unity_daw/pull/1055
# Cause
Previously the checks within tracktion_SamplerPlugin.cpp were not strict enough to ensure there would be a valid object at `&m - 1` where m is an iterator of midi messages.
# Fix 
## Main Fix
A check to ensure that when the size of the midi message collection is greater than one, that the current element is not the first.
## Bonus Fix
If the pitchwheel value is the base value, no pitchwheel midi message is added.
# Testing
Functional testing.

https://github.com/BeatConnect/bc_unity_daw/assets/133661475/04979b6f-d032-4aa3-a5e2-a73df58e91c7