### PR TITLE
1065 drum machine plugin fixes

### DIFF
--- a/modules/tracktion_engine/midi/bc_Midi.h
+++ b/modules/tracktion_engine/midi/bc_Midi.h
@@ -217,13 +217,24 @@ namespace tracktion { inline namespace engine { namespace BeatConnect
 
 				static juce::String getNoteName(double p_hz)
 				{
-					for (auto element : midiNoteValues)
+					for (auto it = midiNoteValues.begin(); it != midiNoteValues.end(); it++)
 					{
-						if (element.freqHz == p_hz)
-							return element.noteName;
-						if ((&element - 1) != nullptr && (&element + 1) != nullptr)
-							if (p_hz > (&element - 1)->freqHz && p_hz < (&element + 1)->freqHz)
-								return element.noteName;
+						if (it->freqHz == p_hz)
+							return it->noteName;
+						if (it > midiNoteValues.begin() && it < midiNoteValues.end()) {
+							if (p_hz > (it - 1)->freqHz && p_hz < (it + 1)->freqHz)
+							{
+								return it->noteName;
+							}
+							else if (p_hz < midiNoteValues.begin()->freqHz)
+							{
+								return midiNoteValues.begin()->noteName;
+							}
+							else if (p_hz > midiNoteValues.end()->freqHz)
+							{
+								midiNoteValues.end()->noteName;
+							}
+						}
 					}
 					return "";
 				}

--- a/modules/tracktion_engine/midi/bc_Midi.h
+++ b/modules/tracktion_engine/midi/bc_Midi.h
@@ -169,13 +169,13 @@ namespace tracktion { inline namespace engine { namespace BeatConnect
 
 				static int getMidiNote(double p_hz)
 				{
-					for (auto element : midiNoteValues)
+					for (auto it = midiNoteValues.begin(); it != midiNoteValues.end(); it++)
 					{
-						if (element.freqHz == p_hz)
-							return element.midiNote;
-						if ((&element - 1) != nullptr && (&element + 1) != nullptr)
-							if (p_hz > (&element - 1)->freqHz && p_hz < (&element + 1)->freqHz)
-								return element.midiNote;
+						if (it->freqHz == p_hz)
+							return it->midiNote;
+						if (it > midiNoteValues.begin() && it < midiNoteValues.end() && p_hz > (it - 1)->freqHz && p_hz < (it + 1)->freqHz) {
+							return it->midiNote;
+						}
 					}
 					return -1;
 				}

--- a/modules/tracktion_engine/midi/bc_Midi.h
+++ b/modules/tracktion_engine/midi/bc_Midi.h
@@ -173,8 +173,19 @@ namespace tracktion { inline namespace engine { namespace BeatConnect
 					{
 						if (it->freqHz == p_hz)
 							return it->midiNote;
-						if (it > midiNoteValues.begin() && it < midiNoteValues.end() && p_hz > (it - 1)->freqHz && p_hz < (it + 1)->freqHz) {
-							return it->midiNote;
+						if (it > midiNoteValues.begin() && it < midiNoteValues.end()) {
+							if (p_hz > (it - 1)->freqHz && p_hz < (it + 1)->freqHz)
+							{
+								return it->midiNote;
+							}
+							else if (p_hz < midiNoteValues.begin()->freqHz)
+							{
+								return midiNoteValues.begin()->freqHz;
+							}
+							else if (p_hz > midiNoteValues.end()->freqHz)
+							{
+								midiNoteValues.end()->freqHz;
+							}
 						}
 					}
 					return -1;

--- a/modules/tracktion_engine/model/clips/tracktion_StepClip.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_StepClip.cpp
@@ -409,8 +409,10 @@ void StepClip::generateMidiSequenceForChannels (juce::MidiMessageSequence& resul
                         auto chan = c.channel.get().getChannelNumber();
                         
                         // BEATCONNECT MODIFICATION START
-                        float pitchWheelPosition = juce::MidiMessage::pitchbendToPitchwheelPos(cache->getKeyNoteOffset(i), DrumMachinePlugin::pitchWheelSemitoneRange);
-                        result.addEvent (juce::MidiMessage::pitchWheel(chan, pitchWheelPosition), eventStart);
+                        if (cache->getKeyNoteOffset(i) != 0) {
+                            float pitchWheelPosition = juce::MidiMessage::pitchbendToPitchwheelPos(cache->getKeyNoteOffset(i), DrumMachinePlugin::pitchWheelSemitoneRange);
+                            result.addEvent (juce::MidiMessage::pitchWheel(chan, pitchWheelPosition), eventStart);
+                        }
                         // BEATCONNECT MODIFICATION END
                         result.addEvent (juce::MidiMessage::noteOn (chan, note, vel * channelVelScale), eventStart);
                         result.addEvent (juce::MidiMessage::noteOff (chan, note, (uint8_t) juce::jlimit (0, 127, c.noteValue.get())), eventEnd);

--- a/modules/tracktion_engine/model/clips/tracktion_StepClip.h
+++ b/modules/tracktion_engine/model/clips/tracktion_StepClip.h
@@ -211,7 +211,7 @@ public:
 
         // BEATCONNECT MODIFICATIONS START
         // Midi only has 127 available notes, guaranteed to be out of range.
-        errorKeyNoteOffset  = -127,
+        noKeyNoteOffset  = 0,
         errorTremoloAttacks = -1,
         // BEATCONNECT MODIFICATIONS END
 

--- a/modules/tracktion_engine/model/clips/tracktion_StepClipPattern.cpp
+++ b/modules/tracktion_engine/model/clips/tracktion_StepClipPattern.cpp
@@ -186,7 +186,7 @@ void StepClip::Pattern::setNote (int channel, int index, bool value)
 // BEATCONNECT MODIFICATION START
 int StepClip::Pattern::getKeyNoteOffset(int channel, int index) const {
     if (!getNote(channel, index))
-        return errorKeyNoteOffset;
+        return noKeyNoteOffset;
 
     auto keyNoteOffsets = getKeyNoteOffsets(channel);
 
@@ -196,7 +196,7 @@ int StepClip::Pattern::getKeyNoteOffset(int channel, int index) const {
     if (clip.getChannels()[channel] != nullptr)
         return defaultKeyNoteOffset;
 
-    return errorKeyNoteOffset;
+    return defaultKeyNoteOffset;
 }
 
 juce::Array<int> StepClip::Pattern::getKeyNoteOffsets(int channel) const {

--- a/modules/tracktion_engine/plugins/effects/tracktion_SamplerPlugin.cpp
+++ b/modules/tracktion_engine/plugins/effects/tracktion_SamplerPlugin.cpp
@@ -309,9 +309,7 @@ void SamplerPlugin::applyToBuffer (const PluginRenderContext& fc)
 
                 if (m.isNoteOn())
                 {
-                    // BEATCONNECT MODIFICATION START
-                    int note = m.getNoteNumber();
-                    // BEATCONNECT MODIFICATION END
+                    const int note = m.getNoteNumber();
                     const int noteTimeSample = juce::roundToInt (m.getTimeStamp() * sampleRate);
 
                     for (auto playingNote : playingNotes)
@@ -327,6 +325,7 @@ void SamplerPlugin::applyToBuffer (const PluginRenderContext& fc)
 
                     for (auto ss : soundList)
                     {
+                        int adjustedMidiNote = note;
                         if (ss->minNote <= note
                             && ss->maxNote >= note
                             && ss->audioData.getNumSamples() > 0
@@ -340,11 +339,14 @@ void SamplerPlugin::applyToBuffer (const PluginRenderContext& fc)
                             // and given system constants, solve for the new note values
                             double noteHz = BeatConnect::MidiNote::getNoteFrequency(ss->keyNote);
                             double newNoteHz = BeatConnect::MidiNote::getFrequencyByPitchWheel(pitchWheelPosition, DrumMachinePlugin::pitchWheelSemitoneRange, noteHz);
-                            note = BeatConnect::MidiNote::getMidiNote(newNoteHz);
+                            adjustedMidiNote = BeatConnect::MidiNote::getMidiNote(newNoteHz);
                         }
                         // BEATCONNECT MODIFICATION END
                             highlightedNotes.setBit (note);
-                            playingNotes.add (new SampledNote (note,
+                            playingNotes.add (new SampledNote 
+                                                               // BEATCONNECT MODIFICATION START
+                                                               (adjustedMidiNote,
+                                                               // BEATCONNECT MODIFICATION END
                                                                ss->keyNote,
                                                                m.getVelocity() / 127.0f,
                                                                ss->audioFile,


### PR DESCRIPTION
Improved default values for when proper conversion to midi note is not possible.

Better range checks for frequencies at the ends of the midi table, and between values.
# Testing
Functional testing in progress...