### PR TITLE
1292 - Include AirWindows Plugins to KnownPluginList

### DIFF
--- a/modules/tracktion_engine/plugins/airwindows/tracktion_AirWindows.cpp
+++ b/modules/tracktion_engine/plugins/airwindows/tracktion_AirWindows.cpp
@@ -149,6 +149,10 @@ AirWindowsPlugin::AirWindowsPlugin (PluginCreationInfo info, std::unique_ptr<Air
     addAutomatableParameter (dryGain = new PluginWetDryAutomatableParam ("dry level", TRANS("Dry Level"), *this));
     addAutomatableParameter (wetGain = new PluginWetDryAutomatableParam ("wet level", TRANS("Wet Level"), *this));
 
+    // BEATCONNECT MODIFICATION START
+    info.state.setProperty(IDs::manufacturer, "AirWindows", um);
+    // BEATCONNECT MODIFICATION END
+
     dryValue.referTo (state, IDs::dry, um);
     wetValue.referTo (state, IDs::wet, um, 1.0f);
 

--- a/modules/tracktion_engine/plugins/airwindows/tracktion_AirWindows.cpp
+++ b/modules/tracktion_engine/plugins/airwindows/tracktion_AirWindows.cpp
@@ -206,9 +206,9 @@ void AirWindowsPlugin::applyToBuffer (const PluginRenderContext& fc)
 
     SCOPED_REALTIME_CHECK
 
-        for (auto p : parameters)
-            if (auto awp = dynamic_cast<AirWindowsAutomatableParameter*> (p))
-                impl->setParameter (awp->index, awp->getCurrentValue());
+    for (auto p : parameters)
+        if (auto awp = dynamic_cast<AirWindowsAutomatableParameter*> (p))
+            impl->setParameter (awp->index, awp->getCurrentValue());
 
     juce::AudioBuffer<float> asb (fc.destBuffer->getArrayOfWritePointers(), fc.destBuffer->getNumChannels(),
                                   fc.bufferStartSample, fc.bufferNumSamples);

--- a/modules/tracktion_engine/plugins/airwindows/tracktion_AirWindows.cpp
+++ b/modules/tracktion_engine/plugins/airwindows/tracktion_AirWindows.cpp
@@ -149,10 +149,6 @@ AirWindowsPlugin::AirWindowsPlugin (PluginCreationInfo info, std::unique_ptr<Air
     addAutomatableParameter (dryGain = new PluginWetDryAutomatableParam ("dry level", TRANS("Dry Level"), *this));
     addAutomatableParameter (wetGain = new PluginWetDryAutomatableParam ("wet level", TRANS("Wet Level"), *this));
 
-    // BEATCONNECT MODIFICATION START
-    info.state.setProperty(IDs::manufacturer, "AirWindows", um);
-    // BEATCONNECT MODIFICATION END
-
     dryValue.referTo (state, IDs::dry, um);
     wetValue.referTo (state, IDs::wet, um, 1.0f);
 
@@ -192,6 +188,7 @@ int AirWindowsPlugin::getNumOutputChannelsGivenInputs (int)
 void AirWindowsPlugin::initialise (const PluginInitialisationInfo& info)
 {
     sampleRate = info.sampleRate;
+    getVendor();
 }
 
 void AirWindowsPlugin::deinitialise()
@@ -210,9 +207,10 @@ void AirWindowsPlugin::applyToBuffer (const PluginRenderContext& fc)
 
     SCOPED_REALTIME_CHECK
 
-    for (auto p : parameters)
-        if (auto awp = dynamic_cast<AirWindowsAutomatableParameter*> (p))
-            impl->setParameter (awp->index, awp->getCurrentValue());
+        for (auto p : parameters) {
+            if (auto awp = dynamic_cast<AirWindowsAutomatableParameter*> (p))
+                impl->setParameter (awp->index, awp->getCurrentValue());
+    }
 
     juce::AudioBuffer<float> asb (fc.destBuffer->getArrayOfWritePointers(), fc.destBuffer->getNumChannels(),
                                   fc.bufferStartSample, fc.bufferNumSamples);

--- a/modules/tracktion_engine/plugins/airwindows/tracktion_AirWindows.cpp
+++ b/modules/tracktion_engine/plugins/airwindows/tracktion_AirWindows.cpp
@@ -188,7 +188,6 @@ int AirWindowsPlugin::getNumOutputChannelsGivenInputs (int)
 void AirWindowsPlugin::initialise (const PluginInitialisationInfo& info)
 {
     sampleRate = info.sampleRate;
-    getVendor();
 }
 
 void AirWindowsPlugin::deinitialise()
@@ -207,10 +206,9 @@ void AirWindowsPlugin::applyToBuffer (const PluginRenderContext& fc)
 
     SCOPED_REALTIME_CHECK
 
-        for (auto p : parameters) {
+        for (auto p : parameters)
             if (auto awp = dynamic_cast<AirWindowsAutomatableParameter*> (p))
                 impl->setParameter (awp->index, awp->getCurrentValue());
-    }
 
     juce::AudioBuffer<float> asb (fc.destBuffer->getArrayOfWritePointers(), fc.destBuffer->getNumChannels(),
                                   fc.bufferStartSample, fc.bufferNumSamples);

--- a/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
+++ b/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
@@ -991,11 +991,8 @@ Plugin::Ptr PluginCache::createNewPlugin (const juce::ValueTree& v)
     auto p = addPluginToCache (edit.engine.getPluginManager().createNewPlugin (edit, v));
 
     // BEATCONNECT MODIFICATIONS START
-    std::string test = p.get()->getPluginType().toStdString();
     if (p.get()->getPluginType() == v.getType().toString()) 
-    {
         p.get()->state.setProperty(IDs::uniqueId, p.get()->getUniqueId(), nullptr);
-    }
     // BEATCONNECT MODIFICATIONS END
 
     if (p != nullptr && newPluginAddedCallback != nullptr)

--- a/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
+++ b/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
@@ -737,12 +737,16 @@ Plugin::Ptr PluginManager::createNewPlugin (Edit& ed, const juce::String& type, 
                 v.setProperty (IDs::windowLocked, true, nullptr);
 
             // BEATCONNECT MODIFICATIONS START
+            if (desc.category.startsWith("airwindows"))
+                v.setProperty(IDs::manufacturer, "AirWindows", nullptr);
+
             if (type == "drum machine")
                 addInitialSamplerDrumPadValueTree(v);
             // BEATCONNECT MODIFICATIONS END
 
             if (auto p = builtIn->create(PluginCreationInfo(ed, v, true)))
             {
+                std::string debug = p->edit.state.createXml().get()->toString().toStdString();
                 addPluginParametersToValueTree(p);
                 return p;
             }
@@ -988,10 +992,11 @@ Plugin::Ptr PluginCache::createNewPlugin (const juce::ValueTree& v)
 
     // BEATCONNECT MODIFICATIONS START
     std::string test = p.get()->getPluginType().toStdString();
-    if (p.get()->getPluginType() == v.getType().toString()) { // untested
+    if (p.get()->getPluginType() == v.getType().toString()) 
+    {
         p.get()->state.setProperty(IDs::uniqueId, p.get()->getUniqueId(), nullptr);
     }
-    // BEATCONNECT MODIFICATIONS START
+    // BEATCONNECT MODIFICATIONS END
 
     if (p != nullptr && newPluginAddedCallback != nullptr)
         newPluginAddedCallback (*p);

--- a/modules/tracktion_engine/utilities/tracktion_Engine.cpp
+++ b/modules/tracktion_engine/utilities/tracktion_Engine.cpp
@@ -70,6 +70,7 @@ void Engine::initialise()
         deviceManager->initialise();
 
     pluginManager->initialise();
+    pluginManager->initialiseAirWindows(); // =8> Debug
     getProjectManager().initialise();
 
     externalControllerManager->initialise();

--- a/modules/tracktion_engine/utilities/tracktion_Engine.cpp
+++ b/modules/tracktion_engine/utilities/tracktion_Engine.cpp
@@ -70,7 +70,9 @@ void Engine::initialise()
         deviceManager->initialise();
 
     pluginManager->initialise();
-    pluginManager->initialiseAirWindows(); // =8> Debug
+    // BEAT CONNECT MODIFICATION START
+    pluginManager->initialiseAirWindows();
+    // BEAT CONNECT MODIFICATION END
     getProjectManager().initialise();
 
     externalControllerManager->initialise();


### PR DESCRIPTION
Please merge before: https://github.com/BeatConnect/bc_unity_daw/pull/1302
Logic for adding manufacturer property added to modules/tracktion_engine/plugins/tracktion_PluginManager.cpp rather than some other place to keep the changes close to similar sorting of plugin types such as those being done with DrumMachinePlugin.

It could be possible to make changes to the AirWindowsPlugin class to hard code the value of the manufacturer into the plugin description during construction, but more major changes would be required. An example of this process can be seen in ExternalPlugin, where the plugin object is reinitialised after it's first construction.

See https://github.com/BeatConnect/bc_unity_daw/pull/1302 for testing.
