### PR TITLE
1292 - Redux

### DIFF
--- a/modules/tracktion_engine/plugins/airwindows/tracktion_AirWindows.h
+++ b/modules/tracktion_engine/plugins/airwindows/tracktion_AirWindows.h
@@ -73,6 +73,7 @@ public:
     //==============================================================================
     void restorePluginStateFromValueTree (const juce::ValueTree&) override;
     void flushPluginStateToValueTree() override;
+    virtual juce::String getVendor() { return "AirWindows"; }
 
 protected:
     //==============================================================================

--- a/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
+++ b/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
@@ -737,8 +737,8 @@ Plugin::Ptr PluginManager::createNewPlugin (Edit& ed, const juce::String& type, 
                 v.setProperty (IDs::windowLocked, true, nullptr);
 
             // BEATCONNECT MODIFICATIONS START
-            if (desc.category.startsWith("airwindows"))
-                v.setProperty(IDs::manufacturer, "AirWindows", nullptr);
+            //if (desc.category.startsWith("airwindows"))
+            //    v.setProperty(IDs::manufacturer, "AirWindows", nullptr);
 
             if (type == "drum machine")
                 addInitialSamplerDrumPadValueTree(v);
@@ -746,7 +746,6 @@ Plugin::Ptr PluginManager::createNewPlugin (Edit& ed, const juce::String& type, 
 
             if (auto p = builtIn->create(PluginCreationInfo(ed, v, true)))
             {
-                std::string debug = p->edit.state.createXml().get()->toString().toStdString();
                 addPluginParametersToValueTree(p);
                 return p;
             }
@@ -1012,6 +1011,7 @@ Plugin::Ptr PluginCache::createNewPlugin (const juce::String& type, const juce::
 
     if (p.get()->getPluginType() == type) {
         p.get()->state.setProperty(IDs::uniqueId, p.get()->getUniqueId(), nullptr);
+        p.get()->state.setProperty(IDs::manufacturer, p.get()->getVendor(), nullptr);
     }
     // BEATCONNECT MODIFICATIONS END
 

--- a/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
+++ b/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
@@ -737,9 +737,6 @@ Plugin::Ptr PluginManager::createNewPlugin (Edit& ed, const juce::String& type, 
                 v.setProperty (IDs::windowLocked, true, nullptr);
 
             // BEATCONNECT MODIFICATIONS START
-            //if (desc.category.startsWith("airwindows"))
-            //    v.setProperty(IDs::manufacturer, "AirWindows", nullptr);
-
             if (type == "drum machine")
                 addInitialSamplerDrumPadValueTree(v);
             // BEATCONNECT MODIFICATIONS END


### PR DESCRIPTION
Merge before: https://github.com/BeatConnect/bc_unity_daw/pull/1314
# Overview
Now the manufacturer string is baked into BeatConnect and AirWindows plugins as they are added to the the list of known plugins.

Additionally the getVendor() member function is now used to set the manufacturer property whenever a plugin is added to the edit, rather than switching on hard coded cases.