### PR TITLE
Add BeatConnect as a manufacturer of concern

### DIFF
--- a/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
+++ b/modules/tracktion_engine/plugins/tracktion_PluginManager.cpp
@@ -1007,11 +1007,9 @@ Plugin::Ptr PluginCache::createNewPlugin (const juce::String& type, const juce::
     // BEATCONNECT MODIFICATIONS START
     p.get()->state.setProperty(IDs::isInstrument, desc.isInstrument, nullptr);
 
-
-    std::string vendorName = p->getVendor().toStdString(); // =8>
     if (p.get()->getPluginType() == type) {
         p.get()->state.setProperty(IDs::uniqueId, p.get()->getUniqueId(), nullptr);
-        if (p->getVendor() == "AirWindows")
+        if (p->getVendor() == "AirWindows" || p->getVendor() == "BeatConnect")
             p.get()->state.setProperty(IDs::manufacturer, p.get()->getVendor(), nullptr);
     }
     // BEATCONNECT MODIFICATIONS END


### PR DESCRIPTION
Add BeatConnect back to the list of manufacturers whose value is scanned for and added to as a value to plugin nodes.