### PR TITLE
1434 - Reduce Default Volume of Master Volume

### DIFF
--- a/modules/tracktion_engine/model/edit/tracktion_Edit.cpp
+++ b/modules/tracktion_engine/model/edit/tracktion_Edit.cpp
@@ -828,7 +828,9 @@ void Edit::initialiseMasterVolume()
     if (! masterVolState.isValid())
     {
         masterVolState = VolumeAndPanPlugin::create();
-        masterVolState.setProperty (IDs::volume, decibelsToVolumeFaderPosition (-3.0f), nullptr);
+        // BEATCONNECT MODIFICATION START
+        masterVolState.setProperty (IDs::volume, decibelsToVolumeFaderPosition (-4.0f), nullptr);
+        // BEATCONNECT MODIFICATION END
         mvTree.addChild (masterVolState, -1, nullptr);
     }
 


### PR DESCRIPTION
# Overview
The default value for the master volume plugin's volume was too high, it's now lower/
# Testing
## Before
With the value of -3.0 provided to setProperty.
```xml
<MASTERVOLUME uuid="117b1154-b876-4186-b5e9-852fc1ce39eb">
    <PLUGIN type="volume" volume="0.6376281380653381" id="1002" enabled="1" uuid="608e2d26-c975-4883-8e32-3fd11bc936a8" pan="0.0">
      <MACROPARAMETERS id="1003" uuid="0a25f16f-8f52-4ee7-8547-a901b3d84f3f" />
      <MODIFIERASSIGNMENTS uuid="425069a0-9f71-4980-90b3-dc8585cc764e" />
    </PLUGIN>
  </MASTERVOLUME>
```
## After
With the value of -4.0 provided to setProperty.
```xml
  <MASTERVOLUME uuid="12490c2b-16bf-4930-b8f0-96cdca41861d">
    <PLUGIN type="volume" volume="0.6065306663513184" id="1002" enabled="1" uuid="22b9edd4-eee1-4ff6-81ea-f95d6d0b1e25" pan="0.0">
      <MACROPARAMETERS id="1003" uuid="ec31d8a0-c90f-4043-824f-a98d63350010" />
      <MODIFIERASSIGNMENTS uuid="d2137ba8-5ef5-4a95-896c-99199d86c838" />
    </PLUGIN>
  </MASTERVOLUME>
```