### PR TITLE
Merge midi clip modification

### DIFF
--- a/modules/tracktion_engine/model/edit/tracktion_EditUtilities.cpp
+++ b/modules/tracktion_engine/model/edit/tracktion_EditUtilities.cpp
@@ -679,7 +679,10 @@ MidiNote* findNoteForState (const Edit& edit, const juce::ValueTree& v)
     return result;
 }
 
-juce::Result mergeMidiClips (juce::Array<MidiClip*> clips)
+// BEATCONNECT MODIFICATION START
+// juce::Result mergeMidiClips(juce::Array<MidiClip*> clips)
+juce::Result mergeMidiClips (juce::Array<MidiClip*> clips, juce::ValueTree& mergedClip)
+// BEATCONNECT MODIFICATION END
 {
     for (auto c : clips)
         if (c->getClipTrack() == nullptr || c->getClipTrack()->isFrozen (Track::anyFreeze))
@@ -726,6 +729,10 @@ juce::Result mergeMidiClips (juce::Array<MidiClip*> clips)
 
                 newClip->setPosition ({ { startTime, endTime }, TimeDuration() });
                 newClip->getSequence().addFrom (destinationList, &track->edit.getUndoManager());
+
+                // BEATCONNECT MODIFICATION START
+                mergedClip = newClip->state;
+                // BEATCONNECT MODIFICATION END
 
                 for (int i = clips.size(); --i >= 0;)
                     clips.getUnchecked (i)->removeFromParentTrack();

--- a/modules/tracktion_engine/model/edit/tracktion_EditUtilities.h
+++ b/modules/tracktion_engine/model/edit/tracktion_EditUtilities.h
@@ -158,7 +158,7 @@ juce::Array<ClipEffect*> getAllClipEffects (Edit& edit);
 MidiNote* findNoteForState (const Edit&, const juce::ValueTree&);
 
 /** Merges a set of MIDI clips in to one new one. */
-juce::Result mergeMidiClips (juce::Array<MidiClip*>);
+juce::Result mergeMidiClips (juce::Array<MidiClip*>, juce::ValueTree&);
 
 
 //==============================================================================


### PR DESCRIPTION
Had to modify the mergeMidiClip function to return the newly created merged clip. This is necessary in order to have undo redo functionality.